### PR TITLE
Generate RSS feed using real comic strip titles

### DIFF
--- a/gen-feed/feed.go
+++ b/gen-feed/feed.go
@@ -6,25 +6,40 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/gorilla/feeds"
 )
 
-func generateFeed(w io.Writer, startDate time.Time, feedLength int, baseURL string) error {
+// FeedGenerator can build an RSS feed for Dilbert.
+type FeedGenerator struct {
+	BucketName string
+	StripsDir  string
+	StartDate  time.Time
+	FeedLength int
+	S3Client   s3iface.S3API
+}
+
+// Generate builds an RSS feed for Dilbert.
+func (g *FeedGenerator) Generate(w io.Writer) error {
 	feed := &feeds.Feed{
 		Title:       "Dilbert",
 		Link:        &feeds.Link{Href: "http://dilbert.com"},
 		Description: "Dilbert Daily Strip",
 	}
 
-	for i := 0; i < feedLength; i++ {
-		day := startDate.AddDate(0, 0, -i).Truncate(24 * time.Hour)
-		date := fmt.Sprintf("%d-%02d-%02d", day.Year(), day.Month(), day.Day())
-		url := fmt.Sprintf("%s%s.gif", baseURL, date)
+	for i := 0; i < g.FeedLength; i++ {
+		var (
+			day   = g.StartDate.AddDate(0, 0, -i).Truncate(24 * time.Hour)
+			date  = fmt.Sprintf("%d-%02d-%02d", day.Year(), day.Month(), day.Day())
+			url   = fmt.Sprintf("https://%s.s3.amazonaws.com/%s%s.gif", g.BucketName, g.StripsDir, date)
+			title = g.title(date)
+		)
 
 		feed.Add(&feeds.Item{
-			Title:       fmt.Sprintf("Dilbert - %s", date),
+			Title:       title,
 			Link:        &feeds.Link{Href: url},
 			Description: fmt.Sprintf(`<img src="%s">`, url),
 			Id:          url,
@@ -35,15 +50,37 @@ func generateFeed(w io.Writer, startDate time.Time, feedLength int, baseURL stri
 	return feed.WriteRss(w)
 }
 
-func uploadFeed(r io.Reader, bucketName, feedPath string) (string, error) {
-	sess, err := session.NewSession()
-	if err != nil {
-		return "", err
+func (g *FeedGenerator) title(date string) string {
+	title := fmt.Sprintf("Dilbert - %s", date)
+
+	if g.S3Client != nil {
+		out, err := g.S3Client.HeadObject(&s3.HeadObjectInput{
+			Bucket: aws.String(g.BucketName),
+			Key:    aws.String(fmt.Sprintf("%s%s.gif", g.StripsDir, date)),
+		})
+		// Silently return fabricated title on error
+		if err == nil {
+			if v := aws.StringValue(out.Metadata["Title"]); v != "" {
+				title = v
+			}
+		}
 	}
 
-	upload, err := s3manager.NewUploader(sess).Upload(&s3manager.UploadInput{
-		Bucket:      aws.String(bucketName),
-		Key:         aws.String(feedPath),
+	return title
+}
+
+// FeedUploader can upload a Dilbert feed to S3.
+type FeedUploader struct {
+	BucketName string
+	FeedPath   string
+	S3Uploader s3manageriface.UploaderAPI
+}
+
+// Upload uploads a Dilbert feed to S3.
+func (u *FeedUploader) Upload(r io.Reader) (string, error) {
+	upload, err := u.S3Uploader.Upload(&s3manager.UploadInput{
+		Bucket:      aws.String(u.BucketName),
+		Key:         aws.String(u.FeedPath),
 		Body:        r,
 		ContentType: aws.String("text/xml; charset=utf-8"),
 	})

--- a/gen-feed/feed_test.go
+++ b/gen-feed/feed_test.go
@@ -2,21 +2,50 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/google/go-cmp/cmp"
 )
+
+type mockS3Client struct {
+	s3iface.S3API
+	Titles map[string]*string
+}
+
+func (m *mockS3Client) HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	return &s3.HeadObjectOutput{
+		Metadata: map[string]*string{
+			"Title": m.Titles[aws.StringValue(input.Key)],
+		},
+	}, nil
+}
 
 func TestFeedGenerator(t *testing.T) {
 	var buf bytes.Buffer
 	date, _ := time.Parse("2006-01-02", "2018-10-01")
+
+	mockClient := &mockS3Client{
+		Titles: map[string]*string{
+			"strips/2018-10-01.gif": aws.String("Use Company Products"),
+			"strips/2018-09-29.gif": aws.String("Fine Lines"),
+		},
+	}
+
 	g := FeedGenerator{
-		BucketName: "dilbert-feed-example",
+		BucketName: "dilbert-feed-test",
 		StripsDir:  "strips/",
 		StartDate:  date,
 		FeedLength: 3,
+		S3Client:   mockClient,
 	}
 
 	if err := g.Generate(&buf); err != nil {
@@ -33,7 +62,36 @@ func TestFeedGenerator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := cmp.Diff(string(want), string(got)); diff != "" {
+	if diff := cmp.Diff(strings.TrimSpace(string(want)), string(got)); diff != "" {
+		t.Error(diff)
+	}
+}
+
+type mockS3Uploader struct {
+	s3manageriface.UploaderAPI
+}
+
+func (m *mockS3Uploader) Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+	return &s3manager.UploadOutput{
+		Location: fmt.Sprintf("https://%s.s3.amazonaws.com/%s",
+			aws.StringValue(input.Bucket), aws.StringValue(input.Key)),
+	}, nil
+}
+
+func TestFeedUploader(t *testing.T) {
+	u := FeedUploader{
+		BucketName: "dilbert-feed-test",
+		FeedPath:   "some/path/feed.xml",
+		S3Uploader: &mockS3Uploader{},
+	}
+	want := "https://dilbert-feed-test.s3.amazonaws.com/some/path/feed.xml"
+
+	got, err := u.Upload(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/gen-feed/feed_test.go
+++ b/gen-feed/feed_test.go
@@ -9,11 +9,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateFeed(t *testing.T) {
+func TestFeedGenerator(t *testing.T) {
 	var buf bytes.Buffer
 	date, _ := time.Parse("2006-01-02", "2018-10-01")
+	g := FeedGenerator{
+		BucketName: "dilbert-feed-example",
+		StripsDir:  "strips/",
+		StartDate:  date,
+		FeedLength: 3,
+	}
 
-	if err := generateFeed(&buf, date, 3, "https://example.com/strips/"); err != nil {
+	if err := g.Generate(&buf); err != nil {
 		t.Fatal(err)
 	}
 

--- a/gen-feed/testdata/feed.xml
+++ b/gen-feed/testdata/feed.xml
@@ -4,24 +4,24 @@
     <link>http://dilbert.com</link>
     <description>Dilbert Daily Strip</description>
     <item>
-      <title>Dilbert - 2018-10-01</title>
-      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif</link>
-      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif&#34;&gt;</description>
-      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif</guid>
+      <title>Use Company Products</title>
+      <link>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-10-01.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-test.s3.amazonaws.com/strips/2018-10-01.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-10-01.gif</guid>
       <pubDate>Mon, 01 Oct 2018 00:00:00 +0000</pubDate>
     </item>
     <item>
       <title>Dilbert - 2018-09-30</title>
-      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif</link>
-      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif&#34;&gt;</description>
-      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif</guid>
+      <link>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-30.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-30.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-30.gif</guid>
       <pubDate>Sun, 30 Sep 2018 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>Dilbert - 2018-09-29</title>
-      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif</link>
-      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif&#34;&gt;</description>
-      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif</guid>
+      <title>Fine Lines</title>
+      <link>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-29.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-29.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-test.s3.amazonaws.com/strips/2018-09-29.gif</guid>
       <pubDate>Sat, 29 Sep 2018 00:00:00 +0000</pubDate>
     </item>
   </channel>

--- a/gen-feed/testdata/feed.xml
+++ b/gen-feed/testdata/feed.xml
@@ -5,23 +5,23 @@
     <description>Dilbert Daily Strip</description>
     <item>
       <title>Dilbert - 2018-10-01</title>
-      <link>https://example.com/strips/2018-10-01.gif</link>
-      <description>&lt;img src=&#34;https://example.com/strips/2018-10-01.gif&#34;&gt;</description>
-      <guid>https://example.com/strips/2018-10-01.gif</guid>
+      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-10-01.gif</guid>
       <pubDate>Mon, 01 Oct 2018 00:00:00 +0000</pubDate>
     </item>
     <item>
       <title>Dilbert - 2018-09-30</title>
-      <link>https://example.com/strips/2018-09-30.gif</link>
-      <description>&lt;img src=&#34;https://example.com/strips/2018-09-30.gif&#34;&gt;</description>
-      <guid>https://example.com/strips/2018-09-30.gif</guid>
+      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-30.gif</guid>
       <pubDate>Sun, 30 Sep 2018 00:00:00 +0000</pubDate>
     </item>
     <item>
       <title>Dilbert - 2018-09-29</title>
-      <link>https://example.com/strips/2018-09-29.gif</link>
-      <description>&lt;img src=&#34;https://example.com/strips/2018-09-29.gif&#34;&gt;</description>
-      <guid>https://example.com/strips/2018-09-29.gif</guid>
+      <link>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif</link>
+      <description>&lt;img src=&#34;https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif&#34;&gt;</description>
+      <guid>https://dilbert-feed-example.s3.amazonaws.com/strips/2018-09-29.gif</guid>
       <pubDate>Sat, 29 Sep 2018 00:00:00 +0000</pubDate>
     </item>
   </channel>

--- a/get-strip/main.go
+++ b/get-strip/main.go
@@ -73,7 +73,7 @@ func handler(input Input) (*Output, error) {
 	}
 
 	stripPath := fmt.Sprintf("%s%s.gif", env.StripsDir, comic.Date)
-	stripURL, err := uploadStrip(resp.Body, env.BucketName, stripPath)
+	stripURL, err := uploadStrip(resp.Body, env.BucketName, stripPath, comic.Title)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func handler(input Input) (*Output, error) {
 	return &Output{comic, stripURL}, nil
 }
 
-func uploadStrip(r io.Reader, bucketName, stripPath string) (string, error) {
+func uploadStrip(r io.Reader, bucketName, stripPath, title string) (string, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return "", err
@@ -92,7 +92,11 @@ func uploadStrip(r io.Reader, bucketName, stripPath string) (string, error) {
 		Bucket:      aws.String(bucketName),
 		Key:         aws.String(stripPath),
 		ContentType: aws.String("image/gif"),
-		Body:        r,
+		// Add strip title to metadata for gen-feed to create nicer RSS feed entries
+		Metadata: map[string]*string{
+			"Title": aws.String(title),
+		},
+		Body: r,
 	})
 	if err != nil {
 		return "", err

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ export class DilbertFeedStack extends cdk.Stack {
         FEED_PATH: feedPath
       }
     });
-    bucket.grantPut(genFeed);
+    bucket.grantReadWrite(genFeed);
 
     const heartbeatEndpoint = ssm.StringParameter.valueForStringParameter(this, `/${id}/heartbeat-endpoint`);
     const heartbeat = new lambda.Function(this, 'HeartbeatFunc', {


### PR DESCRIPTION
So instead of having titles like `Dilbert - 2020-03-21` in the feed, we now get real titles like `Platinum Level Service`.

Originally, I wanted to use DynamoDB to store & exchange strip metadata, but then I had an epiphany that S3 allows adding metadata to objects. One service less to handle. 💥