### PR TITLE
Run Lambda functions on ARM/Graviton2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ bootstrap: build node_modules
 node_modules:
 	yarn install
 
-TARGET := x86_64-unknown-linux-gnu
+TARGET := aarch64-unknown-linux-gnu
 
 ifneq ($(shell uname -s),Linux)
-  export CC_x86_64_unknown_linux_gnu  = $(TARGET)-gcc
-  export CXX_x86_64_unknown_linux_gnu = $(TARGET)-g++
-  export AR_x86_64_unknown_linux_gnu  = $(TARGET)-ar
-  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER = $(TARGET)-gcc
+  export CC_aarch64_unknown_linux_gnu  = $(TARGET)-gcc
+  export CXX_aarch64_unknown_linux_gnu = $(TARGET)-g++
+  export AR_aarch64_unknown_linux_gnu  = $(TARGET)-ar
+  export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = $(TARGET)-gcc
 endif
 
 LAMBDA_FUNCS := $(notdir $(realpath $(dir $(wildcard src/bin/*/main.rs))))

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PS: The Lambda functions used to be [written in Go](https://github.com/mlafeldt/
 You need the following to build and deploy dilbert-feed:
 
 - Node.js + Yarn
-- Rust + `rustup target add x86_64-unknown-linux-gnu`
+- Rust + `rustup target add aarch64-unknown-linux-gnu`
 - (On macOS, you also need the corresponding [cross compiler toolchain](https://github.com/messense/homebrew-macos-cross-toolchains))
 - Make
 

--- a/infra.ts
+++ b/infra.ts
@@ -12,6 +12,7 @@ import * as tasks from '@aws-cdk/aws-stepfunctions-tasks'
 const LAMBDA_DEFAULTS = {
   handler: 'bootstrap',
   runtime: lambda.Runtime.PROVIDED_AL2,
+  architectures: [lambda.Architecture.ARM_64],
   memorySize: 128,
   timeout: cdk.Duration.seconds(10),
   logRetention: logs.RetentionDays.ONE_MONTH,


### PR DESCRIPTION
AWS announcement:

https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/

Rust supports ARM64 ootb:

https://doc.rust-lang.org/stable/rustc/platform-support.html